### PR TITLE
chore(github-actions): add pnpm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Node
         uses: actions/setup-node@v3
-      - name: Cache Yarn
+      - name: Cache 
         id: cache-nodemodules
         uses: actions/cache@v3
         with:
@@ -50,9 +50,10 @@ jobs:
           key: packages-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             packages-
-      - name: Yarn
+      - name: Pnpm
+        run: npm i -g pnpm
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
-        run: yarn install --immutable
+        run: pnpm install
       - name: Setup NPM Registry
         run: echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}' > ~/.npmrc && npm config get registry && npm whoami
       - name: Lint


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/publish.yml` file to update the Node.js package manager and caching strategy.

Updates to the Node.js package manager and caching strategy:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L45-R56): Changed the caching step name from "Cache Yarn" to "Cache" and updated the package manager from Yarn to Pnpm. The `actions/setup-node` step was removed, and a new step to install Pnpm globally was added. The installation command was also updated to use Pnpm instead of Yarn.
