### PR TITLE
fix(github-actions): fix workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,8 +50,9 @@ jobs:
           key: packages-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             packages-
-      - name: Pnpm
+      - name: Install Pnpm
         run: npm i -g pnpm
+      - name: Pnpm
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
         run: pnpm install
       - name: Setup NPM Registry


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish.yml` file. The change modifies the job names and adds a new step for installing Pnpm.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L53-R55): Updated job name from "Pnpm" to "Install Pnpm" and added a new step to install Pnpm globally before running the Pnpm command.
