### PR TITLE
chore(actions): add should-deploy to publish needs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,7 @@ jobs:
           "${{ secrets.PI_DISCORD_WEBHOOK }}"
 
   publish:
-    needs: [build]
+    needs: [build, should-release]
     if: github.ref == 'refs/heads/master' && needs.should-release.outputs.SKIP != 'true'
     name: Publish
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,18 @@ jobs:
         if: failure()
         run: |
           curl -X POST -H "Content-Type: application/json" \
-          -d '{"content": "## ui-tailwind-theme/${{ github.ref_name }}\n❌ ** FAILED ** / Deu ruim =[\n${{ github.sha }} - ${{ github.event.head_commit.message }}"}' \
+          -d '{
+            "embeds": [
+              {
+                "title": "ui-tailwind-theme/${{ github.ref_name }}",
+                "description": "** FAILED ** / Deu ruim =[",
+                "color": ff0000,
+                "footer": {
+                  "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}",
+                }
+              }
+            ]
+          }' \
           "${{ secrets.PI_DISCORD_WEBHOOK }}"
       - name: Cache 
         id: cache-nodemodules
@@ -72,12 +83,6 @@ jobs:
         with:
           name: build-artifact
           path: ./
-      - name: Discord Message on Failure
-        if: failure()
-        run: |
-          curl -X POST -H "Content-Type: application/json" \
-          -d '{"content": "## ui-tailwind-theme/${{ github.ref_name }}\n❌ ** FAILED ** / Deu ruim =[\n${{ github.sha }} - ${{ github.event.head_commit.message }}"}' \
-          "${{ secrets.PI_DISCORD_WEBHOOK }}"
 
   publish:
     needs: [build, should-release]
@@ -93,7 +98,18 @@ jobs:
         if: failure()
         run: |
           curl -X POST -H "Content-Type: application/json" \
-          -d '{"content": "## ui-tailwind-theme/${{ github.ref_name }}\n❌ ** FAILED ** / Deu ruim =[\n${{ github.sha }} - ${{ github.event.head_commit.message }}"}' \
+          -d '{
+            "embeds": [
+              {
+                "title": "ui-tailwind-theme/${{ github.ref_name }}",
+                "description": "** FAILED ** / Deu ruim =[",
+                "color": ff0000,
+                "footer": {
+                  "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}",
+                }
+              }
+            ]
+          }' \
           "${{ secrets.PI_DISCORD_WEBHOOK }}"
       - name: Download Build Artifact
         uses: actions/download-artifact@v4
@@ -122,6 +138,17 @@ jobs:
     steps:
       - name: Discord Message on Success
         run: |
-          curl -X POST -H "Content-Type: application/json" \
-          -d '{"content": "## ui-tailwind-theme/${{ github.ref_name }}\n🎨 **DEPLOYED** / Uma linha de CSS!\n${{ github.sha }} - ${{ github.event.head_commit.message }}"}' \
+        curl -X POST -H "Content-Type: application/json" \
+          -d '{
+            "embeds": [
+              {
+                "title": "ui-tailwind-theme/${{ github.ref_name }}",
+                "description": "🎨 **DEPLOYED** / Uma linha de CSS!",
+                "color": 00ff00,
+                "footer": {
+                  "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}",
+                }
+              }
+            ]
+          }' \
           "${{ secrets.PI_DISCORD_WEBHOOK }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -139,16 +139,16 @@ jobs:
       - name: Discord Message on Success
         run: |
           curl -X POST -H "Content-Type: application/json" \
-            -d '{
-              "embeds": [
-                {
-                  "title": "ui-tailwind-theme/${{ github.ref_name }}",
-                  "description": "🎨 **DEPLOYED** / Uma linha de CSS!",
-                  "color": 00ff00,
-                  "footer": {
-                    "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}"
-                  }
+          -d '{
+            "embeds": [
+              {
+                "title": "ui-tailwind-theme/${{ github.ref_name }}",
+                "description": "🎨 **DEPLOYED** / Uma linha de CSS!",
+                "color": 00ff00,
+                "footer": {
+                  "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}"
                 }
-              ]
-            }' \
-            "${{ secrets.PI_DISCORD_WEBHOOK }}"
+              }
+            ]
+          }' \
+          "${{ secrets.PI_DISCORD_WEBHOOK }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
               {
                 "title": "ui-tailwind-theme/${{ github.ref_name }}",
                 "description": "** FAILED ** / Deu ruim =[",
-                "color": ff0000,
+                "color": 16711680,
                 "footer": {
                   "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}"
                 }
@@ -103,7 +103,7 @@ jobs:
               {
                 "title": "ui-tailwind-theme/${{ github.ref_name }}",
                 "description": "** FAILED ** / Deu ruim =[",
-                "color": ff0000,
+                "color": 16711680,
                 "footer": {
                   "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}"
                 }
@@ -144,7 +144,7 @@ jobs:
               {
                 "title": "ui-tailwind-theme/${{ github.ref_name }}",
                 "description": "🎨 **DEPLOYED** / Uma linha de CSS!",
-                "color": 00ff00,
+                "color": 65280,
                 "footer": {
                   "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}"
                 }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,7 @@ jobs:
             "embeds": [
               {
                 "title": "ui-tailwind-theme/${{ github.ref_name }}",
+                "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                 "description": "** FAILED ** / Deu ruim =[",
                 "color": 16711680,
                 "footer": {
@@ -102,6 +103,7 @@ jobs:
             "embeds": [
               {
                 "title": "ui-tailwind-theme/${{ github.ref_name }}",
+                "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                 "description": "** FAILED ** / Deu ruim =[",
                 "color": 16711680,
                 "footer": {
@@ -143,6 +145,7 @@ jobs:
             "embeds": [
               {
                 "title": "ui-tailwind-theme/${{ github.ref_name }}",
+                "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                 "description": "🎨 **DEPLOYED** / Uma linha de CSS!",
                 "color": 65280,
                 "footer": {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,17 +138,17 @@ jobs:
     steps:
       - name: Discord Message on Success
         run: |
-        curl -X POST -H "Content-Type: application/json" \
-          -d '{
-            "embeds": [
-              {
-                "title": "ui-tailwind-theme/${{ github.ref_name }}",
-                "description": "🎨 **DEPLOYED** / Uma linha de CSS!",
-                "color": 00ff00,
-                "footer": {
-                  "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}",
+          curl -X POST -H "Content-Type: application/json" \
+            -d '{
+              "embeds": [
+                {
+                  "title": "ui-tailwind-theme/${{ github.ref_name }}",
+                  "description": "🎨 **DEPLOYED** / Uma linha de CSS!",
+                  "color": 00ff00,
+                  "footer": {
+                    "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}",
+                  }
                 }
-              }
-            ]
-          }' \
-          "${{ secrets.PI_DISCORD_WEBHOOK }}"
+              ]
+            }' \
+            "${{ secrets.PI_DISCORD_WEBHOOK }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
                 "description": "** FAILED ** / Deu ruim =[",
                 "color": ff0000,
                 "footer": {
-                  "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}",
+                  "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}"
                 }
               }
             ]
@@ -105,7 +105,7 @@ jobs:
                 "description": "** FAILED ** / Deu ruim =[",
                 "color": ff0000,
                 "footer": {
-                  "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}",
+                  "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}"
                 }
               }
             ]
@@ -146,7 +146,7 @@ jobs:
                   "description": "🎨 **DEPLOYED** / Uma linha de CSS!",
                   "color": 00ff00,
                   "footer": {
-                    "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}",
+                    "text": "${{ github.sha }} - ${{ github.event.head_commit.message }}"
                   }
                 }
               ]


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish.yml` file. The change ensures that the `publish` job depends on the `should-release` job in addition to the `build` job.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L83-R83): Modified the `publish` job to include a dependency on the `should-release` job.
