### PR TITLE
Feature cpi 1800

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,23 +47,14 @@ jobs:
         uses: actions/setup-node@v3
       - name: Discord Message on Failure
         if: failure()
-        run: |
-          COMMIT_MESSAGE=$(echo "${{ github.event.head_commit.message }}" | tr -d '\n')
-          curl -X POST -H "Content-Type: application/json" \
-          -d '{
-            "embeds": [
-              {
-                "title": "ui-tailwind-theme/${{ github.ref_name }}",
-                "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                "description": "** FAILED ** / Deu ruim =[",
-                "color": 16711680,
-                "footer": {
-                  "text": "${{ github.sha }} - '"$COMMIT_MESSAGE"'"
-                }
-              }
-            ]
-          }' \
-          "${{ secrets.PI_DISCORD_WEBHOOK }}"
+        uses: vitorvmrs/discord-send-embed@9351e64705943a3a72decd50df587acc8bc89e1c
+        with:
+          webhook-url: ${{ secrets.PI_DISCORD_WEBHOOK }}
+          title: "ui-tailwind-theme/${{ github.ref_name }}"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          description: "❌ FAILED / Deu ruim =["
+          color: 16711680
+          footer-text: "${{ github.sha }} - ${{ github.event.head_commit.message }}"
       - name: Cache 
         id: cache-nodemodules
         uses: actions/cache@v3
@@ -98,23 +89,14 @@ jobs:
         uses: actions/setup-node@v3
       - name: Discord Message on Failure
         if: failure()
-        run: |
-          COMMIT_MESSAGE=$(echo "${{ github.event.head_commit.message }}" | tr -d '\n')
-          curl -X POST -H "Content-Type: application/json" \
-          -d '{
-            "embeds": [
-              {
-                "title": "ui-tailwind-theme/${{ github.ref_name }}",
-                "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                "description": "** FAILED ** / Deu ruim =[",
-                "color": 16711680,
-                "footer": {
-                  "text": "${{ github.sha }} - '"$COMMIT_MESSAGE"'"
-                }
-              }
-            ]
-          }' \
-          "${{ secrets.PI_DISCORD_WEBHOOK }}"
+        uses: vitorvmrs/discord-send-embed@9351e64705943a3a72decd50df587acc8bc89e1c
+        with:
+          webhook-url: ${{ secrets.PI_DISCORD_WEBHOOK }}
+          title: "ui-tailwind-theme/${{ github.ref_name }}"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          description: "❌ FAILED / Deu ruim =["
+          color: 16711680
+          footer-text: "${{ github.sha }} - ${{ github.event.head_commit.message }}"
       - name: Download Build Artifact
         uses: actions/download-artifact@v4
         with:
@@ -146,6 +128,6 @@ jobs:
           webhook-url: ${{ secrets.PI_DISCORD_WEBHOOK }}
           title: "ui-tailwind-theme/${{ github.ref_name }}"
           url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          description: "🎨 **DEPLOYED** / Uma linha de CSS =]"
+          description: "🎨 DEPLOYED / Uma linha de CSS =]"
           color: 65280
-          footer-text: "${{ github.sha }} - ${{ needs.should-release.outputs.CURRENT_VERSION }}"
+          footer-text: "${{ github.sha }} - ${{ github.event.head_commit.message }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Discord Message on Success
-        uses: vitorvmrs/discord-send-embed@32c1be0659400337d2a8525bd1e2a80f963f10b3
+        uses: vitorvmrs/discord-send-embed@20695c6e02a956cceb2c02b2f4ad40c8722a744a
         with:
           webhook-url: ${{ secrets.PI_DISCORD_WEBHOOK }}
           title: "ui-tailwind-theme/${{ github.ref_name }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,20 +141,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Discord Message on Success
-        run: |
-          COMMIT_MESSAGE=$(echo "${{ github.event.head_commit.message }}" | tr -d '\n')
-          curl -X POST -H "Content-Type: application/json" \
-          -d '{
-            "embeds": [
-              {
-                "title": "ui-tailwind-theme/${{ github.ref_name }}",
-                "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                "description": "🎨 **DEPLOYED** / Uma linha de CSS!",
-                "color": 65280,
-                "footer": {
-                  "text": "${{ github.sha }} - '"$COMMIT_MESSAGE"'"
-                }
-              }
-            ]
-          }' \
-          "${{ secrets.PI_DISCORD_WEBHOOK }}"
+        uses: vitorvmrs/discord-send-embed@32c1be0659400337d2a8525bd1e2a80f963f10b3
+        with:
+          webhook-url: ${{ secrets.PI_DISCORD_WEBHOOK }}
+          title: "ui-tailwind-theme/${{ github.ref_name }}"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          description: "🎨 **DEPLOYED** / Uma linha de CSS =]"
+          color: 65280
+          footer-text: "${{ github.sha }} - ${{ needs.should-release.outputs.CURRENT_VERSION }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Discord Message on Success
-        uses: vitorvmrs/discord-send-embed@20695c6e02a956cceb2c02b2f4ad40c8722a744a
+        uses: vitorvmrs/discord-send-embed@9351e64705943a3a72decd50df587acc8bc89e1c
         with:
           webhook-url: ${{ secrets.PI_DISCORD_WEBHOOK }}
           title: "ui-tailwind-theme/${{ github.ref_name }}"


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish.yml` file to simplify and standardize the way Discord messages are sent on workflow success or failure. The main changes involve replacing custom `curl` commands with the `vitorvmrs/discord-send-embed` GitHub Action.

Standardization of Discord messages:

* Replaced custom `curl` commands with the `vitorvmrs/discord-send-embed` GitHub Action for sending Discord messages on workflow failure. This change simplifies the code and ensures consistency. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L50-R57) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L101-R99)
* Updated the workflow to use the `vitorvmrs/discord-send-embed` GitHub Action for sending Discord messages on workflow success, ensuring a consistent approach across different workflow outcomes.
