### PR TITLE
chore:(workflow): add github repo name on discord message

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
         uses: vitorvmrs/discord-send-embed@0f0cb61f7ed052734cc11765a5b2c5d0a5c3d9c2
         with:
           webhook-url: ${{ secrets.PI_DISCORD_WEBHOOK }}
-          title: "ui-tailwind-theme/${{ github.ref_name }}"
+          title: "${{ github.repository }}/${{ github.ref_name }}"
           url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           description: "❌ FAILED / Deu ruim =["
           color: 16711680
@@ -92,7 +92,7 @@ jobs:
         uses: vitorvmrs/discord-send-embed@0f0cb61f7ed052734cc11765a5b2c5d0a5c3d9c2
         with:
           webhook-url: ${{ secrets.PI_DISCORD_WEBHOOK }}
-          title: "ui-tailwind-theme/${{ github.ref_name }}"
+          title: "${{ github.repository }}/${{ github.ref_name }}"
           url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           description: "❌ FAILED / Deu ruim =["
           color: 16711680
@@ -126,7 +126,7 @@ jobs:
         uses: vitorvmrs/discord-send-embed@0f0cb61f7ed052734cc11765a5b2c5d0a5c3d9c2
         with:
           webhook-url: ${{ secrets.PI_DISCORD_WEBHOOK }}
-          title: "ui-tailwind-theme/${{ github.ref_name }}"
+          title: "${{ github.repository }}/${{ github.ref_name }}"
           url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           description: "🎨 DEPLOYED / Uma linha de CSS =]"
           color: 65280


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/publish.yml` file to improve the Discord notification titles. The changes modify the titles to include the full repository name instead of just the branch name.

Improvements to Discord notification titles:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L53-R53): Changed the `title` field in the Discord notification configuration to use `${{ github.repository }}/${{ github.ref_name }}` instead of `ui-tailwind-theme/${{ github.ref_name }}`. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L53-R53) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L95-R95) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L129-R129)
